### PR TITLE
Όταν κάνεις duplicate μια φόρμα, τα πεδία που έχουν επισημανθεί ως υποχρεωτικά, αντιγράφονται ως μη-υποχρεωτικά

### DIFF
--- a/app/Http/Controllers/Admin/FormsController.php
+++ b/app/Http/Controllers/Admin/FormsController.php
@@ -512,6 +512,7 @@ class FormsController extends Controller
             $field->sort_id = $item->sort_id;
             $field->title = $item->title;
             $field->type = $item->type;
+            $field->required = $item->required;
             $field->listvalues = $item->listvalues;
             $form_clone->form_fields()->save($field);
         }


### PR DESCRIPTION
Fixes #103